### PR TITLE
Updated Climate Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ npm install climate-si7005
 ```
 ##Example
 ```js
-var climate = require('climate-si7005').use(hardwareapi);
+var climatelib = require('climate-si7005');
+var tessel = require('tessel');
+
+var climate = climatelib.use(tessel.port['A']);
 climate.on('ready', function () {
   climate.readTemperature('f', function (err, temp) {
     console.log('Degrees:', temp.toFixed(4) + 'F');

--- a/examples/climate.js
+++ b/examples/climate.js
@@ -3,10 +3,11 @@ This basic climate example logs a stream
 of temperature and humidity to the console.
 *********************************************/
 
+console.log('Starting up si7005... on port bank A');
+var climatelib = require('climate-si7005');
 var tessel = require('tessel');
 
-console.log('Starting up si7005... on port bank A');
-var climate = require('../').use(tessel.port('A'));
+var climate = climatelib.use(tessel.port['A']);
 
 climate.on('ready', function () {
   console.log('Connected to si7005');


### PR DESCRIPTION
Previous climate module docs used require('climate-si7005').use(hardwareapi). Changed it to require('climate-si7005').use(tessel.port['A']).

Reviewers: @tcr @jiahuang 
