### PR TITLE
fixed setHeater and setFastMeasurement

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,10 @@ ClimateSensor.prototype.setHeater = function (status) {
   if (status) {
     this._configReg |= CONFIG_HEAT;
   } else {
-    this._configReg ^= CONFIG_HEAT;
+    if (this._configReg)
+    {
+      this._configReg ^= CONFIG_HEAT;
+    }
   }
 };
 
@@ -257,7 +260,9 @@ ClimateSensor.prototype.setFastMeasure = function  (status) {
   if (status) {
     this._configReg |= CONFIG_FAST;
   } else {
-    this._configReg ^= CONFIG_FAST;
+    if (this._configReg) {
+      this._configReg ^= CONFIG_FAST;
+    }
   }
 };
 


### PR DESCRIPTION
In the previous code, if either the heater or fast measurement setting was off and you tried to turn it off, it would turn them on. This is because 0 xor 0 equals 1.

Reviewed by: @tcr @jiahuang @ekolker
