### PR TITLE
adds example for polling 2 climate modules off one port

### DIFF
--- a/examples/2climate1port.js
+++ b/examples/2climate1port.js
@@ -46,6 +46,7 @@ var port = tessel.port['A'];
 
 // Because the climate module is so low power, we can run it off a GPIO
 var state = false;
+// ...But we need to multiplex them if we want to share the I2C bus
 var one = port.digital[1].output(state);
 var two = port.digital[2].output(!state);
 


### PR DESCRIPTION
This hack that lets us use as many climate modules as we have GPIOs at (almost) the same time, all off one port's I2C bus.
