### PR TITLE
getData t2 cannot use digitalWrite to set cs high

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,8 +159,9 @@ ClimateSensor.prototype.getData = function (configValue, next) {
             self._readRegister(DATAh, function (err, datah) {
               self._readRegister(DATAl, function (err, datal) {
 
-                self.hardware.digital[self.csn].write(1);
-                next(null, datal | datah << 8);
+                self.hardware.digital[self.csn].write(1, function(err, data){
+                  next(err, datal | datah << 8);
+                });
               });
             });
           });

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ ClimateSensor.prototype.getData = function (configValue, next) {
             self._readRegister(DATAh, function (err, datah) {
               self._readRegister(DATAl, function (err, datal) {
 
-                self.hardware.digitalWrite(self.csn, 1);
+                self.hardware.digital[self.csn].write(1);
                 next(null, datal | datah << 8);
               });
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climate-si7005",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "The library for using the Climate si7005 module for Tessel. Get temperature and humidity.",
   "main": "index.js",
   "readmeFilename:": "README.md",


### PR DESCRIPTION
self.hardware does not have a digitalWrite method on it in the tessel 2 runtime, so use the `self.hardware.digital[_offset_].write()` call instead to accomplish the same thing.  Closes #23 because the si-7005 can now be used on the tessel 2, and still as well on the tessel 1 (tested with my tessel 1 board) 